### PR TITLE
re-add gzip on webpages, bypassing chat events

### DIFF
--- a/django_map/settings.py
+++ b/django_map/settings.py
@@ -60,6 +60,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "maps.middleware.SelectiveGZipMiddleware",
 ]
 
 ROOT_URLCONF = "django_map.urls"

--- a/maps/middleware.py
+++ b/maps/middleware.py
@@ -1,0 +1,11 @@
+from django.middleware.gzip import GZipMiddleware
+
+class SelectiveGZipMiddleware(GZipMiddleware):
+    """
+    A custom GZip middleware that skips compression for Server-Sent Events (SSE)
+    to prevent proxy and browser buffering issues.
+    """
+    def process_response(self, request, response):
+        if "text/event-stream" in response.get("Content-Type", ""):
+            return response
+        return super().process_response(request, response)

--- a/maps/middleware.py
+++ b/maps/middleware.py
@@ -1,5 +1,6 @@
 from django.middleware.gzip import GZipMiddleware
 
+
 class SelectiveGZipMiddleware(GZipMiddleware):
     """
     A custom GZip middleware that skips compression for Server-Sent Events (SSE)

--- a/maps/middleware.py
+++ b/maps/middleware.py
@@ -6,6 +6,7 @@ class SelectiveGZipMiddleware(GZipMiddleware):
     A custom GZip middleware that skips compression for Server-Sent Events (SSE)
     to prevent proxy and browser buffering issues.
     """
+
     def process_response(self, request, response):
         if "text/event-stream" in response.get("Content-Type", ""):
             return response


### PR DESCRIPTION
I had disabled the streaming gzip compression because it was breaking the chat events.  I have re-enabled it explicitly bypassing gzip for the SSE (server sent events) events for chat.